### PR TITLE
feat: add rule to enforce semantic versioning for API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,76 @@ You can also use it directly from unpkg:
 echo 'extends: ["https://unpkg.com/@luxass/spectral-ruleset"]' > .spectral.yml
 ```
 
+## Rules
+
+This ruleset extends the official OpenAPI and AsyncAPI rulesets from `@stoplight/spectral-rulesets`, with some built-in rules modified (`operation-tags` and `operation-operationId` are disabled, `operation-success-response` is set to error level).
+
+### Custom Rules
+
+<details>
+<summary><strong>General Rules</strong></summary>
+
+##### `luxass/api-homepage` ⚠️
+Ensures that APIs have a root path (`/`) defined. This helps with API discoverability and provides a clear entry point for consumers.
+
+##### `luxass/api-homepage-get` ⚠️
+Ensures that the API root path (`/`) has a GET operation defined. This allows consumers to discover what the API offers.
+
+##### `luxass/version-in-info` ⚠️
+Enforces semantic versioning format for the `info.version` field (e.g., `1.0.0`).
+
+</details>
+
+<details>
+<summary><strong>Path Rules</strong></summary>
+
+##### `luxass/paths-kebab-case` ⚠️
+Enforces kebab-case naming convention for all API paths (e.g., `/user-profiles` instead of `/userProfiles`).
+
+##### `luxass/no-file-extensions-in-paths` ❌
+Prevents file extensions (`.json`, `.xml`, `.html`, `.txt`) in API paths. Use the `content` field to specify media types instead.
+
+##### `luxass/no-trailing-slash` ⚠️
+Prevents trailing slashes in paths (except for the root path `/`), avoiding confusion about resource identity.
+
+##### `luxass/plural-resource-names` ⚠️
+Encourages using plural nouns for resource collections (e.g., `/users` instead of `/user`).
+
+</details>
+
+<details>
+<summary><strong>Header Rules</strong></summary>
+
+##### `luxass/no-x-headers` ❌
+Prevents usage of headers starting with `X-` prefix. Encourages using standardized headers instead of the deprecated X- convention.
+
+##### `luxass/headers-hyphenated-pascal-case` ❌
+Enforces `Hyphenated-Pascal-Case` notation for HTTP headers (e.g., `Content-Type`, `Accept-Language`).
+
+</details>
+
+<details>
+<summary><strong>OpenAPI 2.0 Specific Rules</strong></summary>
+
+##### `luxass/oas2/protocol-https-only` ❌
+Ensures that only HTTPS protocol is used in the `schemes` array.
+
+##### `luxass/oas2/get-request-no-body` ❌
+Prevents GET requests from having request bodies, following HTTP best practices.
+
+</details>
+
+<details>
+<summary><strong>OpenAPI 3.x Specific Rules</strong></summary>
+
+##### `luxass/oas3/protocol-https-only` ❌
+Ensures that all server URLs use HTTPS protocol only.
+
+##### `luxass/oas3/get-request-no-body` ❌
+Prevents GET requests from having `requestBody` defined, following HTTP best practices.
+
+</details>
+
 ## 📄 License
 
 Published under [MIT License](./LICENSE).

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -89,6 +89,18 @@ export default {
         },
       },
     },
+    "luxass/version-in-info": {
+      message: "API version should follow semantic versioning.",
+      description: "The info.version field should follow semantic versioning (e.g., 1.0.0).",
+      given: "$.info.version",
+      then: {
+        function: pattern,
+        functionOptions: {
+          match: "^\\d+\\.\\d+\\.\\d+",
+        },
+      },
+      severity: DiagnosticSeverity.Warning,
+    },
     ...oas2Rules,
     ...oas3Rules,
   },

--- a/test/version-in-info.test.ts
+++ b/test/version-in-info.test.ts
@@ -1,0 +1,98 @@
+import { DiagnosticSeverity } from "@stoplight/types";
+import { spectralRuleTest } from "./__utils";
+
+spectralRuleTest("luxass/version-in-info", [
+  {
+    name: "valid semantic version",
+    document: {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {},
+    },
+    errors: [],
+  },
+  {
+    name: "valid semantic version with pre-release",
+    document: {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0-alpha.1",
+      },
+      paths: {},
+    },
+    errors: [],
+  },
+  {
+    name: "valid semantic version with build metadata",
+    document: {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0+20230101",
+      },
+      paths: {},
+    },
+    errors: [],
+  },
+  {
+    name: "invalid version - single number",
+    document: {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1",
+      },
+      paths: {},
+    },
+    errors: [
+      {
+        code: "luxass/version-in-info",
+        message: "API version should follow semantic versioning.",
+        path: ["info", "version"],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: "invalid version - two numbers only",
+    document: {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0",
+      },
+      paths: {},
+    },
+    errors: [
+      {
+        code: "luxass/version-in-info",
+        message: "API version should follow semantic versioning.",
+        path: ["info", "version"],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: "invalid version - descriptive text",
+    document: {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "latest",
+      },
+      paths: {},
+    },
+    errors: [
+      {
+        code: "luxass/version-in-info",
+        message: "API version should follow semantic versioning.",
+        path: ["info", "version"],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+]);


### PR DESCRIPTION
- Introduced a new rule `luxass/version-in-info` to validate that the `info.version` field follows semantic versioning (e.g., 1.0.0).
- Added corresponding tests to ensure correct functionality for valid and invalid version formats.